### PR TITLE
Executor as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A CircleCI Orb for Salus
 
 | attribute | description | default | options |
 | --------- | ----------- | ------- | ------- |
+| salus_executor | CircleCI executor to use that specifies Salus environment | `coinbase/salus:2.4.1` | See [executor reference](https://circleci.com/docs/2.0/configuration-reference/#executors-requires-version-21)|
 | active_scanners | Scanners to run | all | Brakeman, PatternSearch, BundleAudit, NPMAudit |
 | enforced_scanners | Scanners that block builds | all | Brakeman, PatternSearch, BundleAudit, NPMAudit |
 | report_uri | Where to send Salus reports | file://test/salus-report.json | Any URI |
@@ -61,4 +62,22 @@ workflows:
       - salus/scan:
           active_scanners: "\n    - Brakeman"
           enforced_scanners: "\n    - Brakeman"
+```
+
+### scan with custom Salus executor
+
+```
+version: 2.1
+orbs:
+  salus: federacy/salus@dev:0.0.1
+executors:
+  salus_latest:
+    docker:
+      - image: coinbase/salus:latest
+workflows:
+  salus_scan:
+    jobs: 
+      - salus/scan:
+          salus_executor:
+            name: salus_latest
 ```

--- a/orb.yml
+++ b/orb.yml
@@ -8,9 +8,13 @@ executors:
       - image: coinbase/salus:2.4.1
 jobs:
   scan:
-    executor: salus
+    executor: << parameters.salus_container >>
     working_directory: /home
     parameters:
+      salus_container:
+        description: Executor for Salus
+        type: executor
+        default: salus
       active_scanners:
         description: Scanners to run
         type: string
@@ -89,4 +93,3 @@ examples:
           jobs: 
             - salus/scan:
                 active_scanners: "\n    - Brakeman"
-

--- a/orb.yml
+++ b/orb.yml
@@ -8,10 +8,10 @@ executors:
       - image: coinbase/salus:2.4.1
 jobs:
   scan:
-    executor: << parameters.salus_container >>
+    executor: << parameters.salus_executor >>
     working_directory: /home
     parameters:
-      salus_container:
+      salus_executor:
         description: Executor for Salus
         type: executor
         default: salus
@@ -93,3 +93,19 @@ examples:
           jobs: 
             - salus/scan:
                 active_scanners: "\n    - Brakeman"
+  specify_executor_scan:
+    description: A Salus scan that blocks on any potential vulnerabilities
+    usage:
+      version: 2.1
+      orbs:
+        salus: federacy/salus@dev:0.0.1
+      executors:
+        salus_latest:
+          docker:
+            - image: coinbase/salus:latest
+      workflows:
+        salus_scan:
+          jobs: 
+            - salus/scan:
+                salus_executor:
+                  name: salus_latest


### PR DESCRIPTION
This PR adds an executor parameter that allows users of the orb to run Salus from a different container (i.e., run a specific non-default version, or their own custom Salus container). 

See https://github.com/coinbase/salus/issues/39#issuecomment-489435490 for context.